### PR TITLE
Add basic console logging to API and template views

### DIFF
--- a/renting/views.py
+++ b/renting/views.py
@@ -1,10 +1,14 @@
+import logging
 from django.shortcuts import render
 from .models import (
     AppUser, VehicleType, Brand, FuelType, Color, Transmission,
     CarModel, Car, Reservation
 )
 
+logger = logging.getLogger(__name__)
+
 def home(request):
+    logger.info("Home page accessed")
     return render(request, 'renting/home.html', {
         'total_users': AppUser.objects.count(),
         'total_cars': Car.objects.count(),
@@ -12,14 +16,19 @@ def home(request):
     })
 
 def user_list(request):
+    logger.info("User list page accessed")
     users = AppUser.objects.all()
     return render(request, 'renting/users/list.html', {'users': users})
 
+
 def car_list(request):
+    logger.info("Car list page accessed")
     cars = Car.objects.select_related('car_model', 'car_model__brand').all()
     return render(request, 'renting/cars/list.html', {'cars': cars})
 
+
 def reservation_list(request):
+    logger.info("Reservation list page accessed")
     reservations = Reservation.objects.select_related('user', 'car', 'car__car_model').all()
     return render(request, 'renting/reservations/list.html', {'reservations': reservations})
 
@@ -35,6 +44,14 @@ from .serializers import (
 class AppUserViewSet(viewsets.ModelViewSet):
     queryset = AppUser.objects.all()
     serializer_class = AppUserSerializer
+
+    def perform_create(self, serializer):
+        user = serializer.save()
+        logger.info(f"User created: {user.email}")
+
+    def perform_destroy(self, instance):
+        logger.info(f"User deleted: {instance.email}")
+        instance.delete()
 
 class VehicleTypeViewSet(viewsets.ModelViewSet):
     queryset = VehicleType.objects.all()
@@ -66,8 +83,28 @@ class CarViewSet(viewsets.ModelViewSet):
     queryset = Car.objects.select_related('car_model', 'car_model__brand', 'color').all()
     serializer_class = CarSerializer
 
+    def perform_create(self, serializer):
+        car = serializer.save()
+        logger.info(f"Car created: {car.license_plate}")
+
+    def perform_destroy(self, instance):
+        logger.info(f"Car deleted: {instance.license_plate}")
+        instance.delete()
+
 class ReservationViewSet(viewsets.ModelViewSet):
     queryset = Reservation.objects.select_related(
         'user', 'car', 'car__car_model', 'car__car_model__brand'
     ).all()
     serializer_class = ReservationSerializer
+
+    def perform_create(self, serializer):
+        reservation = serializer.save()
+        logger.info(
+            f"Reservation created: user={reservation.user.email}, car={reservation.car.license_plate}"
+        )
+
+    def perform_destroy(self, instance):
+        logger.info(
+            f"Reservation deleted: id={instance.id}, user={instance.user.email}"
+        )
+        instance.delete()

--- a/renting_project/settings.py
+++ b/renting_project/settings.py
@@ -134,3 +134,28 @@ USE_TZ = True
 # https://docs.djangoproject.com/en/6.0/howto/static-files/
 
 STATIC_URL = 'static/'
+
+# =========================
+# Logging
+# =========================
+
+LOGGING = {
+    'version': 1,
+    'disable_existing_loggers': False,
+    'formatters': {
+        'simple': {
+            'format': '[{levelname}] {name}: {message}',
+            'style': '{',
+        },
+    },
+    'handlers': {
+        'console': {
+            'class': 'logging.StreamHandler',
+            'formatter': 'simple',
+        },
+    },
+    'root': {
+        'handlers': ['console'],
+        'level': 'INFO',
+    },
+}


### PR DESCRIPTION
What was done
	•	Added basic console logging configuration in settings.py.
	•	Integrated INFO-level logging into template-based views.
	•	Added logging to key API CRUD operations using perform_create and perform_destroy.
	•	Logging is limited to internal console output, following the Essential level requirements.

Related Issue
	•	Add basic logging #10 (Closes)